### PR TITLE
Add library

### DIFF
--- a/lib/chess-enforcer.ts
+++ b/lib/chess-enforcer.ts
@@ -21,17 +21,28 @@ export enum PieceDescription {
     queen = 'queen'
 }
 
-export interface Piece { color?: Team; description?: PieceDescription; symbol?: string; startRank: Rank; startFile: string; };
-export interface Square { color: Team, piece?: Piece, rank: Rank, file: string };
+export interface Piece { color?: Team; description?: PieceDescription; symbol?: string; startRank: Rank; startFile: File; };
+export interface Square { color: Team, piece?: Piece, rank: Rank, file: File};
 export type Board = Square[];
 export type Board2d = {[key: string]: Square}[]
+
+const addGhostPieces = (board: Board): Board => {
+    const output: Board = JSON.parse(JSON.stringify(board));
+    for(const square of output) {
+        if(!square.piece) {
+            square.piece = {startRank: square.rank, startFile: square.file}
+        }
+    }
+    return output
+}
 
 /**
  * @returns A board with all pieces in starting configuration
  */
-export const GetNewBoard = async (): Promise<Board> => {
+export const GetNewBoard = async (ghostPieces = false): Promise<Board> => {
     const res = await fetch('https://us-central1-chess-enforcer-firebase.cloudfunctions.net/getNewChessBoard')
-    const board:Board = await res.json()
+    let board:Board = await res.json()
+    if(ghostPieces) board = addGhostPieces(board)
     return board
 }
 
@@ -86,3 +97,10 @@ export const toBoard2d = (board: Board): Board2d => {
     })
     return output
 }
+
+const main = async () => {
+    const board = toBoard2d(await GetNewBoard(true))
+    console.log(board[5][File.a].piece.startRank)
+}
+
+main()

--- a/lib/chess-enforcer.ts
+++ b/lib/chess-enforcer.ts
@@ -97,10 +97,3 @@ export const toBoard2d = (board: Board): Board2d => {
     })
     return output
 }
-
-const main = async () => {
-    const board = toBoard2d(await GetNewBoard(true))
-    console.log(board[5][File.a].piece.startRank)
-}
-
-main()

--- a/lib/chess-enforcer.ts
+++ b/lib/chess-enforcer.ts
@@ -1,14 +1,14 @@
 export enum Rank { one = 1, two = 2, three = 3, four = 4, five = 5, six = 6, seven = 7, eight = 8 }
 
-export const File = {
-    a: 'a',
-    b: 'b',
-    c: 'c',
-    d: 'd',
-    e: 'e',
-    f: 'f',
-    g: 'g',
-    h: 'h'
+export enum File {
+    a = 'a',
+    b = 'b',
+    c = 'c',
+    d = 'd',
+    e = 'e',
+    f = 'f',
+    g = 'g',
+    h = 'h'
 }
 
 export enum Team { black = 'black', white = 'white' }
@@ -24,6 +24,7 @@ export enum PieceDescription {
 export interface Piece { color?: Team; description?: PieceDescription; symbol?: string; startRank: Rank; startFile: string; };
 export interface Square { color: Team, piece?: Piece, rank: Rank, file: string };
 export type Board = Square[];
+export type Board2d = {[key: string]: Square}[]
 
 /**
  * @returns A board with all pieces in starting configuration
@@ -60,4 +61,28 @@ export const MovePiece = async (fromSquare: Square, toSquare: Square, board: Boa
         })
     })
     return await res.json()
+}
+
+export const toBoard2d = (board: Board): Board2d => {
+    const output: Board2d = []
+    let i = -1
+    board.forEach((square, index) => {
+        if(index % 8 == 0) {
+            output.push({})
+            i++
+        }
+        let file: File
+        switch(index % 8) {
+            case 0: file = File.a; break;
+            case 1: file = File.b; break;
+            case 2: file = File.c; break;
+            case 3: file = File.d; break;
+            case 4: file = File.e; break;
+            case 5: file = File.f; break;
+            case 6: file = File.g; break;
+            case 7: file = File.h; break;
+        }
+        output[i][File[file]] = square
+    })
+    return output
 }

--- a/lib/chess-enforcer.ts
+++ b/lib/chess-enforcer.ts
@@ -1,0 +1,68 @@
+export enum Rank { one = 1, two = 2, three = 3, four = 4, five = 5, six = 6, seven = 7, eight = 8 }
+
+export const File = {
+    a: 'a',
+    b: 'b',
+    c: 'c',
+    d: 'd',
+    e: 'e',
+    f: 'f',
+    g: 'g',
+    h: 'h'
+}
+
+export enum Team { black = 'black', white = 'white' }
+export enum PieceDescription {
+    rook = 'rook',
+    pawn = 'pawn',
+    knight = 'knight',
+    bishop = 'bishop',
+    king = 'king',
+    queen = 'queen'
+}
+
+export interface Piece { color?: Team; description?: PieceDescription; symbol?: string; startRank: Rank; startFile: string; };
+export interface Square { color: Team, piece?: Piece, rank: Rank, file: string };
+export type Board = Square[];
+
+const fetchOpts: RequestInit = {
+    mode: "no-cors"
+}
+
+/**
+ * @returns A board with all pieces in starting configuration
+ */
+export const GetNewBoard = async (): Promise<Board> => {
+    const res = await fetch('https://us-central1-chess-enforcer-firebase.cloudfunctions.net/getNewChessBoard', fetchOpts)
+    const board:Board = await res.json()
+    return board
+}
+
+/**
+ * Moves a piece from a given starting square to a given ending square.
+ * 
+ * @remarks
+ * Returns `undefined` if the given move is illegal.
+ * 
+ * @param fromSquare - The square on which the piece to be moved is located; the starting square
+ * @param toSquare - The square to which the piece is to be moved; the ending square
+ * @param board - The current board state
+ * @param currentTeam - The team whose turn it currently is
+ * @returns The new board after successfully moving the piece
+ */
+export const MovePiece = async (fromSquare: Square, toSquare: Square, board: Board, currentTeam: Team) => {
+    const res = await fetch('https://us-central1-chess-enforcer-firebase.cloudfunctions.net/moveChessPiece', {
+        ...fetchOpts,
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+            fromSquare: fromSquare,
+            toSquare: toSquare,
+            board: board,
+            currentTeam: currentTeam
+        })
+    })
+    return await res.json()
+}

--- a/lib/chess-enforcer.ts
+++ b/lib/chess-enforcer.ts
@@ -25,15 +25,11 @@ export interface Piece { color?: Team; description?: PieceDescription; symbol?: 
 export interface Square { color: Team, piece?: Piece, rank: Rank, file: string };
 export type Board = Square[];
 
-const fetchOpts: RequestInit = {
-    mode: "no-cors"
-}
-
 /**
  * @returns A board with all pieces in starting configuration
  */
 export const GetNewBoard = async (): Promise<Board> => {
-    const res = await fetch('https://us-central1-chess-enforcer-firebase.cloudfunctions.net/getNewChessBoard', fetchOpts)
+    const res = await fetch('https://us-central1-chess-enforcer-firebase.cloudfunctions.net/getNewChessBoard')
     const board:Board = await res.json()
     return board
 }
@@ -52,7 +48,6 @@ export const GetNewBoard = async (): Promise<Board> => {
  */
 export const MovePiece = async (fromSquare: Square, toSquare: Square, board: Board, currentTeam: Team) => {
     const res = await fetch('https://us-central1-chess-enforcer-firebase.cloudfunctions.net/moveChessPiece', {
-        ...fetchOpts,
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',


### PR DESCRIPTION
Add a client-side library to interface with the chess-enforcer web API. This includes types, TSDocs, and a utility function to convert a standard board object (a 1-dimensional array of squares) into a 2-dimensional board object (an array of dictionaries. Each dictionary has keys of file letters with values of squares. This is done to preserve the rank-file number-letter system found elsewhere in chess-enforcer). The GetNewBoard function also allows for the conversion of piece-less squares to squares with "ghost pieces", pieces with only startRank and startFile properties.